### PR TITLE
chore: bump @antelopejs/interface-core to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@antelopejs/interface-api": "^0.0.2",
-    "@antelopejs/interface-core": "^0.0.2"
+    "@antelopejs/interface-core": "^0.0.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.2
@@ -56,6 +56,9 @@ packages:
 
   '@antelopejs/interface-core@0.0.2':
     resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -585,6 +588,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1375,6 +1381,10 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
+  '@antelopejs/interface-core@0.0.3':
+    dependencies:
+      reflect-metadata: 0.2.2
+
   '@biomejs/biome@2.3.2':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.3.2
@@ -1723,7 +1733,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1867,6 +1877,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -1969,7 +1981,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `@antelopejs/interface-core` dependency from `^0.0.2` to `^0.0.3` in both `package.json` and `pnpm-lock.yaml`. The lockfile is correctly regenerated and also reflects a transitive upgrade of `defu` from `6.1.4` to `6.1.7`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal-scope dependency bump with a correctly regenerated lockfile and no logic changes.

Only two files changed: a single version specifier in `package.json` and its corresponding lockfile. The lockfile integrity hashes are present and the transitive dependency change (`defu` 6.1.4 → 6.1.7) is expected. No code logic is touched, so the risk of regression is very low.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps `@antelopejs/interface-core` specifier from `^0.0.2` to `^0.0.3`; no other changes. |
| pnpm-lock.yaml | Lockfile properly updated to resolve `@antelopejs/interface-core@0.0.3` and a transitive bump of `defu` from `6.1.4` to `6.1.7`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@antelopejs/interface-auth"] -->|"^0.0.3 (was ^0.0.2)"| B["@antelopejs/interface-core@0.0.3"]
    A -->|"^0.0.2 (unchanged)"| C["@antelopejs/interface-api@0.0.2"]
    B --> D["reflect-metadata@0.2.2"]
    E["unrs-resolver / giget"] -->|"transitive bump"| F["defu@6.1.7 (was 6.1.4)"]
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-auth/commit/daf1584cf89383b02294e384ecc5d43d97f318e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29167196)</sub>

<!-- /greptile_comment -->