### PR TITLE
chore(deps): interface deps as wide peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "pnpm run build && ajs module test ."
   },
   "devDependencies": {
-    "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
-    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.5",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
     "release": "pnpm run lint && pnpm run prepack && release-it",
     "test": "pnpm run build && ajs module test ."
   },
-  "dependencies": {
-    "@antelopejs/interface-api": "^0.0.3",
-    "@antelopejs/interface-core": "^0.0.3"
-  },
   "devDependencies": {
+    "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
@@ -51,6 +49,10 @@
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,14 +7,13 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.3
+        specifier: '>=0.0.3 <1.0.0'
         version: 0.0.3
       '@antelopejs/interface-core':
-        specifier: ^0.0.3
+        specifier: '>=0.0.3 <1.0.0'
         version: 0.0.3
-    devDependencies:
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     devDependencies:
       '@antelopejs/interface-api':
-        specifier: '>=0.0.3 <1.0.0'
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-core':
-        specifier: '>=0.0.3 <1.0.0'
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2
@@ -50,11 +50,13 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-api@0.0.3':
-    resolution: {integrity: sha512-64UrrttRAjA1LsXwDskh/UVcXDFpH2+gxJHCT+F8YGLPDJE1XzVUW6/YeG441J+zsFJTnaU6Vlt90TwWumcpCA==}
+  '@antelopejs/interface-api@0.0.5':
+    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-core@0.0.3':
-    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1369,11 +1371,11 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api@0.0.3':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-core@0.0.3':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
Move `@antelopejs/interface-*` from dependencies to peerDependencies with wide `>=` ranges. They are runtime singletons provided by the host, so peer ranges avoid dual installs and pinning overrides downstream. Verified: install (peers auto-installed), build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `@antelopejs/interface-api` and `@antelopejs/interface-core` from `dependencies` to `peerDependencies` (range `>=0.0.3 <1.0.0`), adding them as `devDependencies` too so they are available locally — a standard pattern for ecosystem-singleton packages.

- **Dependency restructure**: Both interface packages are now declared as bounded peer dependencies (`>=0.0.3 <1.0.0`) and as `devDependencies` for local builds, replacing the previous `^0.0.3` regular dependency entries.
- **Lockfile update**: `pnpm-lock.yaml` reflects the move to `devDependencies`; both packages still resolve to `0.0.3`, and the snapshot confirms `interface-api@0.0.3` continues to carry `interface-core@0.0.3` as a bundled runtime dependency — meaning the singleton guarantee for `interface-core` is not yet fully achieved by this change alone.

<h3>Confidence Score: 4/5</h3>

Safe to merge as a structural improvement, but the singleton guarantee for interface-core is not fully enforced until interface-api itself stops bundling it as a regular dependency.

The peer dependency restructure is directionally correct and the bounded range (>=0.0.3 <1.0.0) is reasonable. However, the lockfile snapshot confirms that interface-api@0.0.3 still carries interface-core as a bundled runtime dependency, so two copies of interface-core will coexist in node_modules of any consumer that installs this package — which is the exact dual-install the PR intends to prevent.

pnpm-lock.yaml snapshot at lines 1372–1374 confirms the interface-api → interface-core bundled dependency that undermines the singleton goal.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves interface-api and interface-core from dependencies to peerDependencies (range >=0.0.3 <1.0.0), also adds them as devDependencies for local resolution; structure is correct but interface-api@0.0.3 still bundles interface-core as a regular dependency. |
| pnpm-lock.yaml | Lockfile updated to reflect both packages moving to devDependencies; interface-api@0.0.3 and interface-core@0.0.3 resolve correctly, but the snapshot at line 1372–1374 shows interface-api@0.0.3 still carries interface-core@0.0.3 as a bundled dependency. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        A1["@antelopejs/interface-auth"] -->|dependencies ^0.0.3| B1["@antelopejs/interface-api"]
        A1 -->|dependencies ^0.0.3| C1["@antelopejs/interface-core"]
        B1 -->|bundled dep| C1
    end

    subgraph After
        A2["@antelopejs/interface-auth"] -->|peerDependencies >=0.0.3 <1.0.0| B2["@antelopejs/interface-api"]
        A2 -->|peerDependencies >=0.0.3 <1.0.0| C2["@antelopejs/interface-core"]
        A2 -->|devDependencies >=0.0.3 <1.0.0| B2
        A2 -->|devDependencies >=0.0.3 <1.0.0| C2
        B2 -->|still a bundled dep| C2
        style C2 fill:#ffcccc,stroke:#ff0000
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before
        A1["@antelopejs/interface-auth"] -->|dependencies ^0.0.3| B1["@antelopejs/interface-api"]
        A1 -->|dependencies ^0.0.3| C1["@antelopejs/interface-core"]
        B1 -->|bundled dep| C1
    end

    subgraph After
        A2["@antelopejs/interface-auth"] -->|peerDependencies >=0.0.3 <1.0.0| B2["@antelopejs/interface-api"]
        A2 -->|peerDependencies >=0.0.3 <1.0.0| C2["@antelopejs/interface-core"]
        A2 -->|devDependencies >=0.0.3 <1.0.0| B2
        A2 -->|devDependencies >=0.0.3 <1.0.0| C2
        B2 -->|still a bundled dep| C2
        style C2 fill:#ffcccc,stroke:#ff0000
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-auth/commit/67a560b5df22e005b9dfc67bcd14256872b7f522) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37729607)</sub>

<!-- /greptile_comment -->