### PR TITLE
feat(skills): ship a consumer skill with the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "docs",
     "skills"
   ],
   "exports": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "skills"
   ],
   "exports": {
     ".": {
@@ -58,6 +59,9 @@
     "access": "public"
   },
   "antelopeJs": {
-    "test": "src/antelope.test.ts"
+    "test": "src/antelope.test.ts",
+    "skills": [
+      "./skills"
+    ]
   }
 }

--- a/skills/auth-interface/SKILL.md
+++ b/skills/auth-interface/SKILL.md
@@ -71,7 +71,7 @@ Declare `"antelopeJs": { "implements": ["@antelopejs/interface-auth"] }` in the 
 
 ## Gotchas
 
-- `SignRaw` / `ValidateRaw` / `SignServerResponse` are interface proxy calls: they return Promises and only resolve once a provider module is attached. Calls made earlier are queued, not failed — always `await`.
+- `SignRaw` / `ValidateRaw` / `SignServerResponse` are interface proxy calls: they return Promises and only resolve once a provider module is attached. While a provider module is loaded but not yet attached, earlier calls are queued, not failed — always `await`. But when no loaded module provides the interface (e.g. a stubbed `optionalDependencies` entry), the core neutralizes the proxies and those calls reject instead of queuing.
 - Default token source (`internal.defaultSource`): the `x-antelopejs-auth` request header, falling back to the `ANTELOPEJS_AUTH` cookie. `SignServerResponse` sets that same cookie via `Set-Cookie`.
 - `@Authentication(validator?)` accepts an optional validator at the use site; it overrides any validator configured in `CreateAuthDecorator`.
 - Decorators from `CreateAuthDecorator` (including `Authentication`) apply to parameters, properties, and whole classes (class-level registers a provider for the controller) — NOT to methods; decorating a method silently registers nothing and can break other parameter decorators on that handler.

--- a/skills/auth-interface/SKILL.md
+++ b/skills/auth-interface/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: auth-interface
+description: AntelopeJS interface for token-based authentication - signing and verifying auth tokens (SignRaw, ValidateRaw, SignServerResponse) and injecting the verified payload into interface-api controllers via the @Authentication decorator or custom decorators from CreateAuthDecorator. Use when code imports "@antelopejs/interface-auth", when securing controller routes, generating or validating auth/JWT tokens, injecting authenticated user data into handler parameters, or when implementing an auth provider for internal.Verify/internal.Sign.
+category: antelopejs-interface
+tags: [antelopejs, auth, jwt, tokens, decorators]
+---
+
+# @antelopejs/interface-auth
+
+Token authentication for AntelopeJS modules. Two layers:
+
+- **Proxy crossings** (need a provider module loaded, e.g. a JWT module): `internal.Verify` and `internal.Sign`, wrapped by `SignRaw`, `ValidateRaw`, and `SignServerResponse`. Always async.
+- **Consumer-side helpers** (no crossing by themselves): `Authentication` and `CreateAuthDecorator`, which build parameter providers on top of `@antelopejs/interface-api`.
+
+## Imports
+
+All symbols come from the package root (the exports map exposes no other code subpaths):
+
+```ts
+import {
+  Authentication, CreateAuthDecorator,
+  SignRaw, ValidateRaw, SignServerResponse,
+  internal, // provider side only
+  type AuthSource, type AuthVerifier, type AuthValidator,
+  type SignOptions, type VerifyOptions, type CookieOptions,
+} from "@antelopejs/interface-auth";
+```
+
+`@antelopejs/interface-api` and `@antelopejs/interface-core` are peerDependencies — the consuming module must have them installed.
+
+## Consuming
+
+```ts
+import { Controller, Get, Post } from "@antelopejs/interface-api";
+import { Authentication, SignRaw } from "@antelopejs/interface-auth";
+
+interface UserSession { id: string; role: string; }
+
+class UserController extends Controller("/users") {
+  @Post("login")
+  async login() {
+    // Sign a payload into a token (proxy call to the auth provider)
+    return SignRaw({ id: "42", role: "admin" }, { expiresIn: "1h" });
+  }
+
+  @Get("profile")
+  async getProfile(@Authentication() user: UserSession) {
+    // Token was read from the request, verified, and injected
+    return { id: user.id, role: user.role };
+  }
+}
+```
+
+Custom pipelines use `CreateAuthDecorator({ source?, authenticator?, authenticatorOptions?, validator? })`; the callbacks run as `source(req, res)` → `authenticator(data, authenticatorOptions)` → `validator(data)` → injected parameter.
+
+## Providing
+
+An auth backend module implements the two proxy points:
+
+```ts
+import { ImplementInterface } from "@antelopejs/interface-core";
+import { internal } from "@antelopejs/interface-auth";
+
+ImplementInterface(internal, {
+  Verify: (token, options) => decodeAndVerify(token, options), // return payload, throw on invalid
+  Sign: (data, options) => signToken(data, options),           // return token string
+});
+```
+
+Declare `"antelopeJs": { "implements": ["@antelopejs/interface-auth"] }` in the provider's package.json.
+
+## Gotchas
+
+- `SignRaw` / `ValidateRaw` / `SignServerResponse` are interface proxy calls: they return Promises and only resolve once a provider module is attached. Calls made earlier are queued, not failed — always `await`.
+- Default token source (`internal.defaultSource`): the `x-antelopejs-auth` request header, falling back to the `ANTELOPEJS_AUTH` cookie. `SignServerResponse` sets that same cookie via `Set-Cookie`.
+- `@Authentication(validator?)` accepts an optional validator at the use site; it overrides any validator configured in `CreateAuthDecorator`.
+- Decorators from `CreateAuthDecorator` (including `Authentication`) apply to parameters, properties, and whole classes (class-level registers a provider for the controller) — NOT to methods; decorating a method silently registers nothing and can break other parameter decorators on that handler.
+- `expiresIn` / `notBefore` (SignOptions) and `maxAge` (VerifyOptions) accept a number of seconds or a timespan string such as `"1h"`.
+- Rejection is exception-based: a failed verification or validator throws, it does not return `undefined`.
+
+## Deeper reference
+
+See this package's `docs/` chapters — Introduction, Authentication Basics, Token Handling, Parameter Decoration — and the shipped `dist/index.d.ts` for full TSDoc signatures. Do not duplicate them here.

--- a/skills/auth-interface/SKILL.md
+++ b/skills/auth-interface/SKILL.md
@@ -34,19 +34,19 @@ import {
 import { Controller, Get, Post } from "@antelopejs/interface-api";
 import { Authentication, SignRaw } from "@antelopejs/interface-auth";
 
-interface UserSession { id: string; role: string; }
+interface LibrarianSession { id: string; branch: string; }
 
-class UserController extends Controller("/users") {
+class LibrarianController extends Controller("/librarians") {
   @Post("login")
   async login() {
     // Sign a payload into a token (proxy call to the auth provider)
-    return SignRaw({ id: "42", role: "admin" }, { expiresIn: "1h" });
+    return SignRaw({ id: "lib-7", branch: "riverside" }, { expiresIn: "1h" });
   }
 
-  @Get("profile")
-  async getProfile(@Authentication() user: UserSession) {
+  @Get("desk")
+  async getDesk(@Authentication() librarian: LibrarianSession) {
     // Token was read from the request, verified, and injected
-    return { id: user.id, role: user.role };
+    return { id: librarian.id, branch: librarian.branch };
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Adds `skills/<name>-interface/SKILL.md`: a lean, source-grounded consumer guide (imports per subpath, minimal example, gotchas, pointer to the shipped `.d.ts`)
- Wires it for distribution: `antelopeJs.skills: ["./skills"]` + `skills` in the `files` array
- Consumers get it automatically: the antelopejs Claude Code plugin syncs package-shipped skills into `.claude/skills/`; the cms-ai chatbox loads them at runtime
- Content fact-checked against `src/`/`docs/` by an adversarial review pass (imports validated against the exports map, examples verified against real signatures)

## Test plan
N/A (documentation artifact; frontmatter and import paths validated mechanically)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships a consumer-facing skill document for `@antelopejs/interface-auth` and wires it for distribution by extending the `files` array and adding a `skills` key to the `antelopeJs` config in `package.json`. The SKILL.md content was verified against the actual source (header/cookie names, export paths, decorator dispatch model all match).

- **`package.json`**: adds `docs` and `skills` to the npm `files` list — `docs` was previously unpublished, so this increases the installed footprint. The `antelopeJs.skills` field points to `./skills` so the AntelopeJS plugin can sync the guide automatically.
- **`skills/auth-interface/SKILL.md`**: new skill guide covering imports, a consuming example, a provider boilerplate, and a gotchas section; import paths and decorator behavior align with `src/index.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive documentation and packaging changes with no logic modifications.

The change adds a skill guide and updates the npm `files` list. No runtime code is touched. The SKILL.md claims (header/cookie names, export shape, decorator dispatch) were verified against `src/index.ts` and all match.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Adds `docs` and `skills` to the npm `files` array and registers `./skills` under `antelopeJs.skills`; both additions are intentional and consistent with the PR goals. |
| skills/auth-interface/SKILL.md | New consumer skill guide; key claims (header name `x-antelopejs-auth`, cookie name `ANTELOPEJS_AUTH`, single root export, decorator dispatch) all verified against `src/index.ts`. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Consumer as Consumer Module
    participant AntelopePlugin as AntelopeJS Plugin
    participant NPM as npm registry
    participant Claude as Claude Code / cms-ai

    Consumer->>NPM: "npm install @antelopejs/interface-auth"
    NPM-->>Consumer: dist/ + docs/ + skills/
    AntelopePlugin->>Consumer: sync skills/auth-interface/SKILL.md
    AntelopePlugin-->>Claude: .claude/skills/auth-interface/SKILL.md

    Note over Claude: Skill loaded at runtime

    Consumer->>Consumer: "import { Authentication, SignRaw } from "@antelopejs/interface-auth""
    Consumer->>Consumer: "@Authentication() injects verified payload"
    Consumer->>Consumer: SignRaw(payload, options) → proxy → auth provider → token
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Consumer as Consumer Module
    participant AntelopePlugin as AntelopeJS Plugin
    participant NPM as npm registry
    participant Claude as Claude Code / cms-ai

    Consumer->>NPM: "npm install @antelopejs/interface-auth"
    NPM-->>Consumer: dist/ + docs/ + skills/
    AntelopePlugin->>Consumer: sync skills/auth-interface/SKILL.md
    AntelopePlugin-->>Claude: .claude/skills/auth-interface/SKILL.md

    Note over Claude: Skill loaded at runtime

    Consumer->>Consumer: "import { Authentication, SignRaw } from "@antelopejs/interface-auth""
    Consumer->>Consumer: "@Authentication() injects verified payload"
    Consumer->>Consumer: SignRaw(payload, options) → proxy → auth provider → token
```

</a>

<sub>Reviews (5): Last reviewed commit: ["docs(skills): use fictional domains in c..."](https://github.com/antelopejs/interface-auth/commit/0f84ba52c8792a69c4b8c38bd8b15ec6d0af3aea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45477170)</sub>

<!-- /greptile_comment -->