### PR TITLE
fix(auth): route helpers through selected providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@antelopejs/interface-api": "^0.0.5",
-    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-core": ">=0.0.13 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@antelopejs/interface-api": ">=0.0.3 <1.0.0",
-    "@antelopejs/interface-core": ">=0.0.3 <1.0.0"
+    "@antelopejs/interface-core": ">=0.0.13 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     devDependencies:
       '@antelopejs/interface-api':
         specifier: ^0.0.5
-        version: 0.0.5(@antelopejs/interface-core@0.0.5)
+        version: 0.0.5(@antelopejs/interface-core@0.0.13)
       '@antelopejs/interface-core':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: '>=0.0.13 <1.0.0'
+        version: 0.0.13
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2
@@ -55,8 +55,8 @@ packages:
     peerDependencies:
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-core@0.0.5':
-    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
+  '@antelopejs/interface-core@0.0.13':
+    resolution: {integrity: sha512-/QdBq0jcEqQtjkzdZkmmkjn76T8RqiM9ZTFlh8+O6N3vxGW+UxJAGF9ZEJzAhOgtzuLDtnhSLrIYuEZmYQJH8g==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1371,11 +1371,11 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.13)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.5
+      '@antelopejs/interface-core': 0.0.13
 
-  '@antelopejs/interface-core@0.0.5':
+  '@antelopejs/interface-core@0.0.13':
     dependencies:
       reflect-metadata: 0.2.2
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { SetParameterProvider } from "@antelopejs/interface-api";
 import { InterfaceFunction } from "@antelopejs/interface-core";
 import { MakeParameterAndPropertyAndClassDecorator } from "@antelopejs/interface-core/decorators";
+import type { InterfaceFacadeScope } from "@antelopejs/interface-core/facades";
 
 const AuthHeaderName = "x-antelopejs-auth";
 const AuthCookieName = "ANTELOPEJS_AUTH";
@@ -186,6 +187,15 @@ interface ClassDecoratorTarget {
   prototype: object;
 }
 
+type CheckAuthenticationHandler = <T = unknown, R = unknown>(
+  req: IncomingMessage,
+  res: ServerResponse,
+  source?: AuthSource,
+  authenticator?: AuthVerifier<T>,
+  authenticatorOptions?: VerifyOptions,
+  validator?: AuthValidator<T, R>,
+) => Promise<T | R>;
+
 type DecoratorTarget = object;
 type DecoratorKey = string | number | symbol | undefined;
 type DecoratorIndex = number | undefined;
@@ -246,12 +256,12 @@ function createSetCookieHeader(
 
 function resolveAuthDecoratorCallbacks<T, R>(
   callbacks: AuthDecoratorCallbacks<T, R>,
+  defaultSource: AuthSource,
+  defaultAuthenticator: AuthVerifier<T>,
 ): ResolvedAuthDecoratorCallbacks<T, R> {
   return {
-    source: callbacks.source ?? internal.defaultSource,
-    authenticator:
-      callbacks.authenticator ??
-      (internal.defaultAuthenticator as AuthVerifier<T>),
+    source: callbacks.source ?? defaultSource,
+    authenticator: callbacks.authenticator ?? defaultAuthenticator,
     authenticatorOptions: callbacks.authenticatorOptions ?? {},
     validator: callbacks.validator,
   };
@@ -259,10 +269,11 @@ function resolveAuthDecoratorCallbacks<T, R>(
 
 function createAuthParameterProvider<T, R>(
   callbacks: ResolvedAuthDecoratorCallbacks<T, R>,
+  checkAuthentication: CheckAuthenticationHandler,
   validator?: AuthValidator<T, R>,
 ): AuthParameterProvider<T, R> {
   return (context: AuthenticationContext) =>
-    internal.CheckAuthentication(
+    checkAuthentication(
       context.rawRequest,
       context.rawResponse,
       callbacks.source,
@@ -282,6 +293,25 @@ function registerClassParameterProvider<T, R>(
     undefined,
     provider,
   );
+}
+
+async function performAuthentication<T = unknown, R = unknown>(
+  req: IncomingMessage,
+  res: ServerResponse,
+  source: AuthSource,
+  authenticator: AuthVerifier<T>,
+  authenticatorOptions: VerifyOptions,
+  validator?: AuthValidator<T, R>,
+): Promise<T | R> {
+  const verifiedData = await authenticator(
+    source(req, res),
+    authenticatorOptions,
+  );
+  if (!validator) {
+    return verifiedData;
+  }
+
+  return validator(verifiedData);
 }
 
 /**
@@ -321,15 +351,14 @@ export namespace internal {
     authenticatorOptions: VerifyOptions = {},
     validator?: AuthValidator<T, R>,
   ): Promise<T | R> {
-    const verifiedData = await authenticator(
-      source(req, res),
+    return performAuthentication(
+      req,
+      res,
+      source,
+      authenticator,
       authenticatorOptions,
+      validator,
     );
-    if (!validator) {
-      return verifiedData;
-    }
-
-    return validator(verifiedData);
   }
 }
 
@@ -398,10 +427,59 @@ export function SignServerResponse(
   signOptions?: SignOptions,
   cookieOptions?: CookieOptions,
 ): Promise<ServerResponse> {
-  return SignRaw(data, signOptions).then((token) => {
+  return signServerResponse(SignRaw, res, data, signOptions, cookieOptions);
+}
+
+function signServerResponse(
+  signRaw: typeof SignRaw,
+  res: ServerResponse,
+  data: AuthPayload,
+  signOptions?: SignOptions,
+  cookieOptions?: CookieOptions,
+): Promise<ServerResponse> {
+  return signRaw(data, signOptions).then((token) => {
     res.setHeader("Set-Cookie", createSetCookieHeader(token, cookieOptions));
     return res;
   });
+}
+
+function createAuthDecorator<R = unknown, T = unknown>(
+  callbacks: AuthDecoratorCallbacks<T, R>,
+  defaultSource: AuthSource,
+  defaultAuthenticator: AuthVerifier<T>,
+  checkAuthentication: CheckAuthenticationHandler,
+) {
+  const resolvedCallbacks = resolveAuthDecoratorCallbacks(
+    callbacks,
+    defaultSource,
+    defaultAuthenticator,
+  );
+
+  return MakeParameterAndPropertyAndClassDecorator(
+    (
+      target: DecoratorTarget,
+      key: DecoratorKey,
+      index: DecoratorIndex,
+      validator?: AuthValidator<T, R>,
+    ) => {
+      const authValidator = validator ?? resolvedCallbacks.validator;
+      const provider = createAuthParameterProvider(
+        resolvedCallbacks,
+        checkAuthentication,
+        authValidator,
+      );
+
+      if (key === undefined) {
+        registerClassParameterProvider(
+          target as ClassDecoratorTarget,
+          provider,
+        );
+        return;
+      }
+
+      SetParameterProvider(target, key, index, provider);
+    },
+  );
 }
 
 /**
@@ -444,31 +522,11 @@ export function SignServerResponse(
 export function CreateAuthDecorator<R = unknown, T = unknown>(
   callbacks: AuthDecoratorCallbacks<T, R>,
 ) {
-  const resolvedCallbacks = resolveAuthDecoratorCallbacks(callbacks);
-
-  return MakeParameterAndPropertyAndClassDecorator(
-    (
-      target: DecoratorTarget,
-      key: DecoratorKey,
-      index: DecoratorIndex,
-      validator?: AuthValidator<T, R>,
-    ) => {
-      const authValidator = validator ?? resolvedCallbacks.validator;
-      const provider = createAuthParameterProvider(
-        resolvedCallbacks,
-        authValidator,
-      );
-
-      if (key === undefined) {
-        registerClassParameterProvider(
-          target as ClassDecoratorTarget,
-          provider,
-        );
-        return;
-      }
-
-      SetParameterProvider(target, key, index, provider);
-    },
+  return createAuthDecorator(
+    callbacks,
+    internal.defaultSource,
+    internal.defaultAuthenticator as AuthVerifier<T>,
+    internal.CheckAuthentication,
   );
 }
 
@@ -503,3 +561,68 @@ export function CreateAuthDecorator<R = unknown, T = unknown>(
  * @see {@link CreateAuthDecorator}
  */
 export const Authentication = CreateAuthDecorator({});
+
+/** @internal */
+export function BuildInterfaceFacade(
+  _scope: InterfaceFacadeScope,
+  facade: Record<string, unknown>,
+) {
+  const boundInternal = facade.internal as typeof internal;
+  const Verify = boundInternal.Verify;
+  const Sign = boundInternal.Sign;
+  const validateRaw = <T = unknown>(
+    token?: string,
+    options?: VerifyOptions,
+  ): Promise<T> => Verify(token, options) as Promise<T>;
+  const signRaw = (data: AuthPayload, options?: SignOptions) =>
+    Sign(data, options);
+  const defaultAuthenticator: AuthVerifier<unknown> = validateRaw;
+  const checkAuthentication: CheckAuthenticationHandler = <
+    T = unknown,
+    R = unknown,
+  >(
+    req: IncomingMessage,
+    res: ServerResponse,
+    source = internal.defaultSource,
+    authenticator: AuthVerifier<T> = defaultAuthenticator as AuthVerifier<T>,
+    authenticatorOptions = {},
+    validator?: AuthValidator<T, R>,
+  ) =>
+    performAuthentication(
+      req,
+      res,
+      source,
+      authenticator,
+      authenticatorOptions,
+      validator,
+    );
+  const createDecorator = <R = unknown, T = unknown>(
+    callbacks: AuthDecoratorCallbacks<T, R>,
+  ) =>
+    createAuthDecorator(
+      callbacks,
+      internal.defaultSource,
+      defaultAuthenticator as AuthVerifier<T>,
+      checkAuthentication,
+    );
+
+  return {
+    internal: {
+      ...internal,
+      Verify,
+      Sign,
+      defaultAuthenticator,
+      CheckAuthentication: checkAuthentication,
+    },
+    ValidateRaw: validateRaw,
+    SignRaw: signRaw,
+    SignServerResponse: (
+      res: ServerResponse,
+      data: AuthPayload,
+      signOptions?: SignOptions,
+      cookieOptions?: CookieOptions,
+    ) => signServerResponse(signRaw, res, data, signOptions, cookieOptions),
+    CreateAuthDecorator: createDecorator,
+    Authentication: createDecorator({}),
+  };
+}

--- a/src/tests/interface-facade.test.ts
+++ b/src/tests/interface-facade.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import * as Api from "@antelopejs/interface-api";
+import {
+  AmbiguousProviderError,
+  GetInterfaceProxyIdentity,
+} from "@antelopejs/interface-core";
+import { CreateInterfaceFacade } from "@antelopejs/interface-core/facades";
+import {
+  type ModuleExecutionContext,
+  RunWithModuleContext,
+} from "@antelopejs/interface-core/modules";
+import * as Auth from "../index";
+
+function providerContext(provider: string): ModuleExecutionContext {
+  return {
+    module: provider,
+    owner: `${provider}#1`,
+    provider,
+  };
+}
+
+function consumerContext(
+  owner: string,
+  authProvider: string,
+  apiProvider: string,
+): ModuleExecutionContext {
+  const verifyIdentity = GetInterfaceProxyIdentity(Auth.internal.Verify.proxy);
+  const routesIdentity = GetInterfaceProxyIdentity(Api.routesProxy);
+  assert(verifyIdentity);
+  assert(routesIdentity);
+  return {
+    module: "auth-consumer",
+    owner,
+    providerRoutes: {
+      [verifyIdentity]: authProvider,
+      [routesIdentity]: apiProvider,
+    },
+  };
+}
+
+function requestWithToken(token: string): IncomingMessage {
+  return {
+    headers: { "x-antelopejs-auth": token },
+  } as unknown as IncomingMessage;
+}
+
+describe("Auth interface facade", () => {
+  it("routes default Authentication through the consumer provider after await", async () => {
+    const authLeaseA = RunWithModuleContext(
+      providerContext("auth-provider-a"),
+      () =>
+        Auth.internal.Verify.proxy.onCall(async (token) => `a:${token}`, true),
+    );
+    const authLeaseB = RunWithModuleContext(
+      providerContext("auth-provider-b"),
+      () =>
+        Auth.internal.Verify.proxy.onCall(async (token) => `b:${token}`, true),
+    );
+    const registered: Api.RouteHandler[] = [];
+    const apiLease = RunWithModuleContext(providerContext("api-provider"), () =>
+      Api.routesProxy.onHandlers(
+        (_id, handler) => registered.push(handler),
+        () => {},
+        true,
+      ),
+    );
+    const contextA = consumerContext(
+      "auth-consumer#old",
+      "auth-provider-a",
+      "api-provider",
+    );
+    const contextB = consumerContext(
+      "auth-consumer#new",
+      "auth-provider-b",
+      "api-provider",
+    );
+    const authA = CreateInterfaceFacade(Auth, contextA);
+    const authB = CreateInterfaceFacade(Auth, contextB);
+    const apiA = CreateInterfaceFacade(Api, contextA);
+    const apiB = CreateInterfaceFacade(Api, contextB);
+    class ControllerA {
+      handler(authenticated: unknown) {
+        return authenticated;
+      }
+    }
+    class ControllerB {
+      handler(authenticated: unknown) {
+        return authenticated;
+      }
+    }
+    const targetA = ControllerA.prototype;
+    const targetB = ControllerB.prototype;
+    const descriptorA = Object.getOwnPropertyDescriptor(targetA, "handler");
+    const descriptorB = Object.getOwnPropertyDescriptor(targetB, "handler");
+    assert(descriptorA);
+    assert(descriptorB);
+
+    try {
+      const ambiguous = await Auth.ValidateRaw("token").then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      assert(ambiguous instanceof AmbiguousProviderError);
+
+      authA.Authentication()(targetA, "handler", 0);
+      authB.Authentication()(targetB, "handler", 0);
+      apiA.Get("/auth/a")(targetA, "handler", descriptorA);
+      apiB.Get("/auth/b")(targetB, "handler", descriptorB);
+
+      assert.equal(registered.length, 2);
+      assert.strictEqual(registered[0].callback, targetA.handler);
+      assert.strictEqual(registered[1].callback, targetB.handler);
+      const providerA = registered[0].parameters[0]?.provider;
+      const providerB = registered[1].parameters[0]?.provider;
+      assert(providerA);
+      assert(providerB);
+
+      await Promise.resolve();
+
+      const response = {} as ServerResponse;
+      assert.equal(
+        await providerA({
+          rawRequest: requestWithToken("token-a"),
+          rawResponse: response,
+        } as Api.RequestContext),
+        "a:token-a",
+      );
+      assert.equal(
+        await providerB({
+          rawRequest: requestWithToken("token-b"),
+          rawResponse: response,
+        } as Api.RequestContext),
+        "b:token-b",
+      );
+      assert.strictEqual(apiA.HTTPResult, Api.HTTPResult);
+      assert.strictEqual(apiB.HTTPResult, Api.HTTPResult);
+    } finally {
+      Api.routesProxy.unregisterOwner(contextA.owner as string);
+      Api.routesProxy.unregisterOwner(contextB.owner as string);
+      Api.routesProxy.detach(apiLease);
+      Auth.internal.Verify.proxy.detach(authLeaseA);
+      Auth.internal.Verify.proxy.detach(authLeaseB);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add an interface facade builder for Auth's derived helpers
- rebuild `ValidateRaw`, `SignRaw`, `SignServerResponse`, `CreateAuthDecorator`, and `Authentication` from the consumer's automatically bound `internal.Verify` and `internal.Sign`
- preserve the existing application API and decorator syntax
- ensure an `Authentication()` parameter provider invoked later by API keeps the Auth provider selected for the declaring consumer
- require the interface-core release that provides resolver facades

## Bug reproduced
With two Auth providers, the canonical Auth module cannot choose a provider when called outside an active consumer context. The old architecture could therefore pass direct lifecycle calls while failing later:

```ts
class Controller {
  handler(@Authentication() user: User) {}
}
```

`Authentication()` stores a parameter provider during module evaluation. API invokes it later under API's provider context. Before this change, the default authenticator closed over canonical `ValidateRaw`, which reached an ambiguous `internal.Verify` when two Auth providers existed.

The facade builder now creates the same public helpers from the consumer-bound Verify/Sign functions. No HTTP callback or parameter provider is wrapped in an async context.

## Validation
- `pnpm lint`
- `pnpm build`
- focused Auth facade regression passing
- Core end-to-end integration with two real consumer modules, two Auth providers, real Auth/API decorators, an async boundary, and deferred parameter-provider invocation passing
- canonical Auth call in that same regression still fails with `AmbiguousProviderError`, proving the test exercises provider selection rather than a single-provider side effect
- registered HTTP callbacks remain strict-equal
- `git diff --check`

## Release ordering
Publish interface-core and Core first, then release this package alongside/after interface-api #17. No package is published by this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an Auth interface-facade builder so derived signing, verification, response, and decorator helpers retain the provider selected for each consumer.

- Rebuilds public authentication helpers from consumer-bound `internal.Verify` and `internal.Sign`.
- Preserves the existing authentication pipeline while injecting the bound request-time authentication handler into deferred parameter providers.
- Raises the minimum Interface Core version to the release providing resolver facades.
- Adds a two-provider regression test covering deferred authentication after an async boundary.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The rebuilt helpers consistently close over the consumer-bound Verify and Sign functions, preserve the source-verifier-validator pipeline, and are covered by a deferred two-provider regression.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/index.ts | Adds the facade builder and factors helper construction so signing, verification, and deferred decorator providers use consumer-bound interface functions. |
| src/tests/interface-facade.test.ts | Adds regression coverage for two Auth providers, deferred API parameter-provider execution, an async boundary, and preservation of callback identity. |
| package.json | Raises the Interface Core development and peer dependency floor to 0.0.13 for resolver-facade support. |
| pnpm-lock.yaml | Updates the resolved Interface Core dependency and Interface API peer snapshot to 0.0.13. |

</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer
    participant Core as Interface Core
    participant Facade as Auth Facade
    participant API as Deferred API Provider
    participant Auth as Selected Auth Provider
    Consumer->>Core: CreateInterfaceFacade(Auth, context)
    Core->>Facade: BuildInterfaceFacade(scope, bound exports)
    Consumer->>Facade: Authentication()
    Facade->>API: Register parameter provider
    API->>Facade: Invoke provider during request
    Facade->>Auth: Bound Verify(token, options)
    Auth-->>Facade: Verified payload
    Facade-->>API: Authenticated handler value
```

<sub>Reviews (1): Last reviewed commit: ["fix(auth): route helpers through selecte..."](https://github.com/antelopejs/interface-auth/commit/961623029015ea8f81274901b96316befaa588a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56738215)</sub>

<!-- /greptile_comment -->